### PR TITLE
Pipe-quote symbols which would be read as keywords

### DIFF
--- a/fixnum-table-mutating.scm
+++ b/fixnum-table-mutating.scm
@@ -44,7 +44,7 @@
    (define-inline (llrb-node-value-set! n v) (##sys#setslot n 4 v))))
 
 
- (define-type :table: (struct <llrb-fixnum-table>))
+ (define-type |:table:| (struct <llrb-fixnum-table>))
  (define-record-type <llrb-fixnum-table>
    (%make-fixnum-table root)
    fixnum-table?
@@ -121,23 +121,23 @@
    llrb-node-color
    )
 
- (: make-fixnum-table (--> :table:))
+ (: make-fixnum-table (--> |:table:|))
 
  (define (make-fixnum-table)
    (%make-fixnum-table (llrb-node-init! (make-llrb-node #f #f #f  #f #f))))
 
- (: fixnum-table-empty? (:table: --> boolean))
+ (: fixnum-table-empty? (|:table:| --> boolean))
  (define (fixnum-table-empty? table)
    (ensure fixnum-table? table)
    (llrb-node-empty? (root table)))
 
- (: fixnum-table-delete! (:table: fixnum -> *))
+ (: fixnum-table-delete! (|:table:| fixnum -> *))
  (define (fixnum-table-delete! table key)
    (ensure fixnum? key)
    (ensure fixnum-table? table)
    (llrb-node-delete! (root table) key))
 
- (: fixnum-table-set! (:table: fixnum * -> boolean))
+ (: fixnum-table-set! (|:table:| fixnum * -> boolean))
  (define (fixnum-table-set! table key value)
    (ensure fixnum? key)
    (ensure fixnum-table? table)
@@ -148,7 +148,7 @@
    (llrb-node-node-insert! (root table) key #f (make-llrb-node #f #f #f key value) #f)
    #t)
 
- (: fixnum-table-update! (:table: fixnum procedure &rest procedure -> *))
+ (: fixnum-table-update! (|:table:| fixnum procedure &rest procedure -> *))
  (define (fixnum-table-update!1 table key update . default)
    (ensure fixnum? key)
    (ensure fixnum-table? table)
@@ -182,28 +182,28 @@
 	  (lambda () (error "fixnum-table-update! no default" default))))
      result))
 
- (: fixnum-table-ref/default (:table: fixnum * --> *))
+ (: fixnum-table-ref/default (|:table:| fixnum * --> *))
  (define (fixnum-table-ref/default table key default)
    (ensure fixnum? key)
    (ensure fixnum-table? table)
    (let ((node (llrb-node-node-lookup (root table) key)))
      (if node (llrb-node-value node) default)))
 
- (: fixnum-table-ref (:table: fixnum (procedure () *) -> *))
+ (: fixnum-table-ref (|:table:| fixnum (procedure () *) -> *))
  (define (fixnum-table-ref table key default)
    (ensure fixnum? key)
    (ensure fixnum-table? table)
    (let ((node (llrb-node-node-lookup (root table) key)))
      (if node (llrb-node-value node) (default))))
 
- (: fixnum-table-fold ((procedure (fixnum * *) *) * :table: -> *))
+ (: fixnum-table-fold ((procedure (fixnum * *) *) * |:table:| -> *))
  (define (fixnum-table-fold proc init table)
    (ensure fixnum-table? table)
    (llrb-node-node-fold
     (lambda (node init) (proc (llrb-node-key node) (llrb-node-value node) init))
     init (root table)))
 
- (: fixnum-table-for-each ((procedure (fixnum *) *) :table: -> *))
+ (: fixnum-table-for-each ((procedure (fixnum *) *) |:table:| -> *))
  (define (fixnum-table-for-each proc table)
    (ensure fixnum-table? table)
    (llrb-node-node-for-each
@@ -211,13 +211,13 @@
     (root table))
    #f)
 
- (: fixnum-table/min (:table: (procedure () * *) --> * *))
+ (: fixnum-table/min (|:table:| (procedure () * *) --> * *))
  (define (fixnum-table/min table default)
    (ensure fixnum-table? table)
    (let ((node (llrb-node-min (root table))))
      (if node (values (llrb-node-key node) (llrb-node-value node)) (default))))
 
- (: fixnum-table/delete-min! (:table: (procedure () fixnum *) -> * *))
+ (: fixnum-table/delete-min! (|:table:| (procedure () fixnum *) -> * *))
  (define (fixnum-table/delete-min! table default)
    (ensure fixnum-table? table)
    (let ((node (llrb-node-node-delete-min! (root table))))

--- a/llrb-fixnum-table.scm
+++ b/llrb-fixnum-table.scm
@@ -75,7 +75,7 @@
    (syntax-rules ()
      ((_ n) (##sys#slot n 5))))
 
- (define-type :table: (struct <llrb-fixnum-table>))
+ (define-type |:table:| (struct <llrb-fixnum-table>))
  (define-record-type <llrb-fixnum-table>
    (%make-fixnum-table root)
    table?
@@ -135,42 +135,42 @@
    binding-node-color
    )
 
- (: make-table (--> :table:))
+ (: make-table (--> |:table:|))
 
  (define make-table
    (let ((n0 (binding-node-init! (make-binding-node #f #f #f  #f #f))))
      (lambda () (%make-fixnum-table n0))))
 
- (: table-copy (:table: --> :table:))
+ (: table-copy (|:table:| --> |:table:|))
  (define (table-copy table)
    (check-table table 'fixnum-table-copy)
    (%make-fixnum-table (root table)))
 
- (: table-empty? (:table: --> boolean))
+ (: table-empty? (|:table:| --> boolean))
  (define (table-empty? table)
    (ensure table? table)
    (binding-node-empty? (root table)))
 
- (: table-delete! (:table: fixnum -> *))
+ (: table-delete! (|:table:| fixnum -> *))
  (define (table-delete! table key)
    (check-table table 'fixnum-table-delete!)
    (ensure fixnum? key)
    (root-set! table (binding-node-delete (root table) key)))
 
- (: table-set! (:table: fixnum * -> boolean))
+ (: table-set! (|:table:| fixnum * -> boolean))
  (define (table-set! table key value)
    (check-table table 'fixnum-table-set!)
    (ensure fixnum? key)
    (root-set! table (binding-node-insert (root table) key #f (make-binding-node #f #f #f key value) #f)))
 
- (: table-ref/default (:table: fixnum * --> *))
+ (: table-ref/default (|:table:| fixnum * --> *))
  (define (table-ref/default table key default)
    (check-table table 'fixnum-table-ref/default)
    (ensure fixnum? key)
    (let ((node (binding-node-lookup (root table) key)))
      (if node (binding-node-value node) default)))
 
- (: table-ref (:table: fixnum &optional (procedure () *) (procedure (*) *) -> *))
+ (: table-ref (|:table:| fixnum &optional (procedure () *) (procedure (*) *) -> *))
  (define (table-ref table key . thunk+success)
    (check-table table 'fixnum-table-ref)
    (ensure fixnum? key)
@@ -181,7 +181,7 @@
 	 (if (pair? thunk+success) ((car thunk+success))
 	     (error "fixnum-table-ref no key" key)))))
 
- (: table-update! (:table: fixnum procedure &rest procedure -> *))
+ (: table-update! (|:table:| fixnum procedure &rest procedure -> *))
  (define (table-update! table key update . default)
    (check-table table 'fixnum-table-update!)
    (ensure fixnum? key)
@@ -206,7 +206,7 @@
 	     result)
 	   (loop #f (root table))))))
 
- (: table-fold (:table: (procedure (fixnum * *) *) * -> *))
+ (: table-fold (|:table:| (procedure (fixnum * *) *) * -> *))
  (define (table-fold table proc init)
    (check-table table 'fixnum-table-fold)
    (ensure procedure? proc)
@@ -214,7 +214,7 @@
     (lambda (node init) (proc (binding-node-key node) (binding-node-value node) init))
     init (root table)))
 
- (: table-for-each (:table: (procedure (fixnum *) *) -> *))
+ (: table-for-each (|:table:| (procedure (fixnum *) *) -> *))
  (define (table-for-each table proc)
    (check-table table 'fixnum-table-for-each)
    (ensure procedure? proc)
@@ -223,7 +223,7 @@
     (root table))
    #f)
 
- (: table-min (:table: (procedure () * *) --> * *))
+ (: table-min (|:table:| (procedure () * *) --> * *))
  (define (table-min table default)
    (check-table table 'fixnum-table-min)
    (let ((node (binding-node-min (root table))))
@@ -232,7 +232,7 @@
 	   (ensure procedure? default)
 	   (default)))))
 
- (: table-delete-min! (:table: -> * *))
+ (: table-delete-min! (|:table:| -> * *))
  (define (table-delete-min! table)
    (binding-node-delete-min
     (root table)

--- a/llrb-generic-tree.scm
+++ b/llrb-generic-tree.scm
@@ -125,7 +125,7 @@
       (binding-set-update-node
        1 n (binding-node-left n) (binding-node-right n) (binding-node-color n) more))))
 
- (define-type :table-type: (struct llrb-tree-type))
+ (define-type |:table-type:| (struct llrb-tree-type))
  (define-record llrb-tree-type
    key-type?
    lookup
@@ -142,7 +142,7 @@
  (define binding-node-init! #f)
  (define binding-node-empty? #f)
 
- (: make-llrb-treetype* ((or (procedure (*) boolean) false) (procedure (* *) boolean) (procedure (* *) *) --> :table-type:))
+ (: make-llrb-treetype* ((or (procedure (*) boolean) false) (procedure (* *) boolean) (procedure (* *) *) --> |:table-type:|))
  (define (make-llrb-treetype* key-type? equal less)
 
    (define-syntax generic-k-n-eq?
@@ -195,12 +195,12 @@
     binding-node-delete-min
     ))
 
- (define-type :mk-tt-1: (--> :table-type:))
- (define-type :mk-tt-2: ((struct comparator) --> :table-type:))
- (define-type :mk-tt-3:
+ (define-type |:mk-tt-1:| (--> |:table-type:|))
+ (define-type |:mk-tt-2:| ((struct comparator) --> |:table-type:|))
+ (define-type |:mk-tt-3:|
    ((or (procedure (*) boolean) false) (procedure (* *) boolean) (procedure (* *) *)
-    --> :table-type:))
- (: make-llrb-treetype (or :mk-tt-1: :mk-tt-2: :mk-tt-3:))
+    --> |:table-type:|))
+ (: make-llrb-treetype (or |:mk-tt-1:| |:mk-tt-2:| |:mk-tt-3:|))
  
  (define (make-llrb-treetype . args)
    (cond
@@ -228,7 +228,7 @@
 
  ;; 0Xpairs
 
- (: make-binding-set (:table-type: &rest -> (struct <binding-node>)))
+ (: make-binding-set (|:table-type:| &rest -> (struct <binding-node>)))
  (define (make-binding-set type . lst)	; export
    (if (null? lst)
        (empty-binding-set type)
@@ -335,7 +335,7 @@
        outer inner)
       to)))
 
- (define-type :table: (struct <llrb-generic-table>))
+ (define-type |:table:| (struct <llrb-generic-table>))
  (define-record-type <llrb-generic-table>
    (%make-generic-table type root)
    table?
@@ -355,38 +355,38 @@
    (syntax-rules ()
      ((_ obj loc) (typecheckp obj table? loc))))
 
- (: make-table (:table-type: --> :table:))
+ (: make-table (|:table-type:| --> |:table:|))
  (define (make-table type)
    (ensure llrb-tree-type? type)
    (%make-generic-table type (empty-binding-set type)))
 
- (: table-copy (:table: --> :table:))
+ (: table-copy (|:table:| --> |:table:|))
  (define (table-copy table)
    (check-table table 'generic-table-copy)
    (%make-generic-table (llrb-type table) (root table)))
 
- (: table-empty? (:table: --> boolean))
+ (: table-empty? (|:table:| --> boolean))
  (define (table-empty? table)
    (check-table table 'generic-table-empty?)
    (binding-node-empty? (root table)))
 
- (: table-delete! (:table: * -> *))
+ (: table-delete! (|:table:| * -> *))
  (define (table-delete! table key)
    (check-table table 'generic-table-delete!)
    (retry-alter table r root root-set! ((llrb-tree-type-delete (llrb-type table)) r key)))
 
- (: table-set! (:table: * * -> *))
+ (: table-set! (|:table:| * * -> *))
  (define (table-set! table key value)
    (check-table table 'generic-table-set!)
    (let ((nn (%make-new-binding-node key value)))
      (retry-alter table r root root-set! ((llrb-tree-type-insert (llrb-type table)) r key #f nn #f))))
  
- (: table-ref/default (:table: * * --> *))
+ (: table-ref/default (|:table:| * * --> *))
  (define (table-ref/default table key default)
    (check-table table 'generic-table-ref/default)
    (%binding-set-ref/default (llrb-type table) (root table) key default))
 
- (: table-ref (:table: * &optional (procedure () *) (procedure (*) *) -> *))
+ (: table-ref (|:table:| * &optional (procedure () *) (procedure (*) *) -> *))
  (define (table-ref table key . thunk+success)
    (check-table table 'generic-table-ref)
    (%binding-set-ref/thunk
@@ -396,7 +396,7 @@
 	  (error "generic-table-ref unbound key" key)))
     (and (pair? thunk+success) (pair? (cdr thunk+success)) (cadr thunk+success))))
 
- (: table-update! (:table: * (or false procedure) &rest procedure -> *))
+ (: table-update! (|:table:| * (or false procedure) &rest procedure -> *))
  (define (table-update! table key update . default)
    (check-table table 'generic-table-update!)
    (or (eq? update #f) (ensure procedure? update))
@@ -423,7 +423,7 @@
 	     result)
 	   (loop #f (root table))))))
 
- (: table-fold (:table: (procedure (* * :table:) *) * -> *))
+ (: table-fold (|:table:| (procedure (* * |:table:|) *) * -> *))
  (define (table-fold table proc init)
    (check-table table 'generic-table-fold)
    (ensure procedure? proc)
@@ -431,7 +431,7 @@
     (lambda (node init) (proc (binding-node-key node) (binding-node-value node) init))
     init (root table)))
 
- (: table-for-each (:table: (procedure (* *) *) -> *))
+ (: table-for-each (|:table:| (procedure (* *) *) -> *))
  (define (table-for-each table proc)
    (check-table table 'generic-table-for-each)
    (ensure procedure? proc)
@@ -440,7 +440,7 @@
     (root table))
    #f)
 
- (: table-min (:table: (procedure () * *) --> * *))
+ (: table-min (|:table:| (procedure () * *) --> * *))
  (define (table-min table default)
    (check-table table 'generic-table-min)
    (let ((node ((llrb-tree-type-min (llrb-type table)) (root table))))
@@ -449,7 +449,7 @@
 	   (ensure procedure? default)
 	   (default)))))
 
- (: table-delete-min! (:table: -> * *))
+ (: table-delete-min! (|:table:| -> * *))
  (define (table-delete-min! table)
    ((llrb-tree-type-delete-min (llrb-type table))
     (root table)

--- a/llrb-string-table.scm
+++ b/llrb-string-table.scm
@@ -246,7 +246,7 @@
 	  (make-binding-node #f #f #f (binding-node-key n) v))))
     (lambda () (%make-new-binding-node k (dflt)))))
 
- ;; srfi-1::alist-cons compatible
+ ;; srfi-1|::|alist-cons compatible
  (: binding-set-cons (string * (struct <string-binding-node>) --> (struct <string-binding-node>)))
  (define (binding-set-cons k v nodeset) ; export
    (binding-set-insert nodeset k v))
@@ -267,7 +267,7 @@
     (lambda (node init) (binding-node-insert init (binding-node-key node) #f node #f))
     outer inner))
 
- (define-type :table: (struct <llrb-string-table>))
+ (define-type |:table:| (struct <llrb-string-table>))
  (define-record-type <llrb-string-table>
    (%make-string-table root)
    table?
@@ -280,32 +280,32 @@
  (define (make-table)
    (%make-string-table (empty-binding-set)))
 
- (: table-copy (:table: --> :table:))
+ (: table-copy (|:table:| --> |:table:|))
  (define (table-copy table)
    (check-table table 'string-table-copy)
    (%make-string-table (root table)))
 
- (: table-empty? (:table: --> boolean))
+ (: table-empty? (|:table:| --> boolean))
  (define (table-empty? table)
    (check-table table 'string-table-empty?)
    (binding-node-empty? (root table)))
 
- (: table-delete! (:table: string -> *))
+ (: table-delete! (|:table:| string -> *))
  (define (table-delete! table key)
    (check-table table 'string-table-delete!)
    (root-set! table (binding-node-delete (root table) key)))
 
- (: table-set! (:table: string * -> *))
+ (: table-set! (|:table:| string * -> *))
  (define (table-set! table key value)
    (check-table table 'string-table-set!)
    (root-set! table (binding-node-insert (root table) key #f (%make-new-binding-node key value) #f)))
  
- (: table-ref/default (:table: string * --> *))
+ (: table-ref/default (|:table:| string * --> *))
  (define (table-ref/default table key default)
    (check-table table 'string-table-ref/default)
    (%binding-set-ref/default (root table) key default))
 
- (: table-ref (:table: string &optional (procedure () *) (procedure (*) *) -> *))
+ (: table-ref (|:table:| string &optional (procedure () *) (procedure (*) *) -> *))
  (define (table-ref table key . thunk+success)
    (check-table table 'string-table-ref)
    (%binding-set-ref/thunk
@@ -315,7 +315,7 @@
 	  (error "string-table-ref unbound key" key)))
     (and (pair? thunk+success) (pair? (cdr thunk+success)) (cadr thunk+success))))
 
- (: table-update! (:table: string (or false procedure) &rest procedure -> *))
+ (: table-update! (|:table:| string (or false procedure) &rest procedure -> *))
  (define (table-update! table key update . default)
    (check-table table 'string-table-update!)
    (or (eq? update #f) (ensure procedure? update))
@@ -341,7 +341,7 @@
 	     result)
 	   (loop #f (root table))))))
 
- (: table-fold (:table: (procedure (string * :table:) *) * -> *))
+ (: table-fold (|:table:| (procedure (string * |:table:|) *) * -> *))
  (define (table-fold table proc init)
    (check-table table 'string-table-fold)
    (ensure procedure? proc)
@@ -349,7 +349,7 @@
     (lambda (node init) (proc (binding-node-key node) (binding-node-value node) init))
     init (root table)))
 
- (: table-for-each (:table: (procedure (string *) *) -> *))
+ (: table-for-each (|:table:| (procedure (string *) *) -> *))
  (define (table-for-each table proc)
    (check-table table 'string-table-for-each)
    (ensure procedure? proc)
@@ -358,7 +358,7 @@
     (root table))
    #f)
 
- (: table-min (:table: (procedure () * *) --> * *))
+ (: table-min (|:table:| (procedure () * *) --> * *))
  (define (table-min table default)
    (check-table table 'string-table-min)
    (let ((node (binding-node-min (root table))))
@@ -367,7 +367,7 @@
 	   (ensure procedure? default)
 	   (default)))))
 
- (: table-delete-min! (:table: -> * *))
+ (: table-delete-min! (|:table:| -> * *))
  (define (table-delete-min! table)
    (binding-node-delete-min
     (root table)

--- a/llrb-symbol-tree.scm
+++ b/llrb-symbol-tree.scm
@@ -256,7 +256,7 @@
    (checkbinding-node outer 'binding-union)
    (%binding-set-fold (lambda (node init) (%binding-set-insert init (%binding-node-name node) #f node #f)) outer inner))
 
- (define-type :table: (struct <llrb-symbol-table>))
+ (define-type |:table:| (struct <llrb-symbol-table>))
  (define-record-type <llrb-symbol-table>
    (%make-symbol-table root)
    table?
@@ -266,35 +266,35 @@
    (syntax-rules ()
      ((_ obj loc) (typecheckp obj table? loc))))
 
- (: make-table ( --> :table:))
+ (: make-table ( --> |:table:|))
  (define (make-table)
    (%make-symbol-table (empty-binding-set)))
 
- (: table-copy (:table: --> :table:))
+ (: table-copy (|:table:| --> |:table:|))
  (define (table-copy table)
    (check-table table 'symbol-table-copy)
    (%make-symbol-table (root table)))
 
- (: table-delete! (:table: symbol -> *))
+ (: table-delete! (|:table:| symbol -> *))
  (define (table-delete! table key)
    (check-table table 'symbol-table-delete!)
    (ensure symbol? key)
    (root-set! table (binding-node-delete (root table) (%symbol->string key))))
 
- (: table-set! (:table: symbol * -> *))
+ (: table-set! (|:table:| symbol * -> *))
  (define (table-set! table key value)
    (check-table table 'symbol-table-set!)
    (ensure symbol? key)
    (let ((key (%symbol->string key)))
      (root-set! table (%binding-set-insert (root table) key #f (%make-new-binding-node key value) #f))))
 
- (: table-ref/default (:table: symbol * --> *))
+ (: table-ref/default (|:table:| symbol * --> *))
  (define (table-ref/default table key default)
    (check-table table 'symbol-table-ref/default)
    (ensure symbol? key)
    (%binding-set-ref/default (root table) (%symbol->string key) default))
 
- (: table-ref (:table: symbol &optional (procedure () *) (procedure (*) *) -> *))
+ (: table-ref (|:table:| symbol &optional (procedure () *) (procedure (*) *) -> *))
  (define (table-ref table key . thunk+success)
    (check-table table 'symbol-table-ref)
    (ensure symbol? key)
@@ -305,7 +305,7 @@
 	  (error "symbol-table-ref unbound key" key)))
     (and (pair? thunk+success) (pair? (cdr thunk+success)) (cadr thunk+success))))
 
- (: table-update! (:table: symbol procedure &rest procedure -> *))
+ (: table-update! (|:table:| symbol procedure &rest procedure -> *))
  (define (table-update! table key update . default)
    (check-table table 'symbol-table-update!)
    (ensure symbol? key)


### PR DESCRIPTION
Since CHICKEN 5.0.2, keywords can no longer be bound to values.  There
was a strange quirk in older CHICKENs where it allowed keywords to
behave a lot like but not quite like symbols.

Another way to fix this would be to use a different naming convention for types, or to use `-keyword-style none` when compiling but it looks like keywords are used for other things too so I decided not to do this. The current patch shouldn't change the user-facing API.